### PR TITLE
add default table names to config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+        "php": ">=5.4.0",
         "nategood/httpful": "*",
         "zaininnari/html-minifier": "dev-master",
         "mpdf/mpdf": "dev-master"

--- a/config/localConfig.template.php
+++ b/config/localConfig.template.php
@@ -30,8 +30,8 @@ $db_host = '';
 $db_user = '';
 $db_password = '';
 $db_name = '';
-$db_user_table = '';
-$db_reports_table = '';
+$db_user_table = 'user';
+$db_reports_table = 'reports';
 
 $debug = false;
 
@@ -302,5 +302,3 @@ $udoit_tests = [
         ],
     ],
 ];
-
-?>


### PR DESCRIPTION
The table names aren't likely to change per user, and we give them the sql to create the tables in the readme, so might as well set the default values in the config.