### PR TITLE
Issue #91 addressed - PDF Styles restored

### DIFF
--- a/public/parsePdf.php
+++ b/public/parsePdf.php
@@ -32,7 +32,7 @@ ini_set('max_execution_time', 300);
 $pdf = new mPDF();
 
 $stylesheet = <<<EOD
-<link rel="stylesheet" href="../assets/css/pdf.css" type="text/css">
+<link rel="stylesheet" href="assets/css/pdf.css" type="text/css">
 EOD;
 
 session_start();


### PR DESCRIPTION
Turns out when the files directory was changed, it caused the stylesheet for the pdf to be incorrectly be referenced in parsePdf.php

Issue now addressed