### PR TITLE
Updates heroku env vars for oauth keys to expect input values

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,12 +23,10 @@
       "generator": "secret"
     },
     "OAUTH2_ID": {
-      "description": "Oauth ID from the developer api key created by your admin",
-      "generator": "secret"
+      "description": "Oauth ID from the developer api key created by your admin"
     },
     "OAUTH2_KEY": {
-      "description": "Oauth Key from the developer api key created by your admin",
-      "generator": "secret"
+      "description": "Oauth Key from the developer api key created by your admin"
     },
     "OAUTH2_URI": {
       "description": "Full url to your oauth2responce.php file",


### PR DESCRIPTION
The app.json file for Heroku defines the oauth id and key as auto-generated secret values.  These need to be input fields so this changes them from auto-generated to input fields.