### PR TITLE
Clarify install.md instructions.

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,5 @@
 ###> symfony/framework-bundle ###
-APP_ENV=dev
+APP_ENV=prod
 
 ###> doctrine/doctrine-bundle ###
 DATABASE_URL=mysql://root:root@127.0.0.1:3306/udoit3

--- a/HEROKU.md
+++ b/HEROKU.md
@@ -12,9 +12,11 @@ After clicking the Heroku button above:
 2. Give the app a name.
 3. Set `APP_ENV` to prod for the production version of UDOIT. Please note: The dev environment is not available on Heroku.
 4. Set `APP_LMS` to the name of your LMS.
+   * `canvas` if you are using the Canvas LMS.
+   * `d2l` if you are using the D2l Brightspace LMS.
 5. Fill out the `BASE_URL` field with `https://yourapp.herokuapp.com`. (Replace 'yourapp' with the name you gave in step 2.)
-5. Fill out the `JWK_BASE_URL` field with the URL to your LMS. The default value works for instructure hosted instances of Canvas, but will need to be modified according to the LMS and host.
-6. Click the Deploy button and wait for the process to complete.
+6. Fill out the `JWK_BASE_URL` field with the URL to your LMS. The default value works for instructure hosted instances of Canvas, but will need to be modified according to the LMS and host.
+7. Click the Deploy button and wait for the process to complete.
 
 ### Step 2: Clone UDOIT and Push to Heroku
 1. Follow the instruction under the ['Source Code' section of INSTALL.md](https://github.com/ucfopen/UDOIT/blob/main/INSTALL.md#source-code).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,10 +57,16 @@ Assuming you have Composer installed, navigate to your UDOIT directory in the CL
 
 ## .ENV Setup
 UDOIT uses a `.env` file for storing configuration. Local configuration such as database information and URLs should be stored in a `.env.local` file that is NOT tracked in Git.
-* Rename the file `.env.local.example` to `.env.local`.
-* Add your database information to this `.env.local` file.
-* Add the `BASE_URL`, which is the full URL to reach the `public` folder of UDOIT. (i.e. https://udoit3.ciditools.com)
-* You can optionally change the default language for your entire UDOIT instance by overriding the DEFAULT_LANG variable. Currently supported languages are English (en) and Spanish (es).
+1. Copy the file `.env.local.example` to `.env.local`.
+2. Change `APP_ENV` to
+   * `dev` if you are setting up a development environment
+   * `prod` if you are setting up a production server
+3. Add your database information to this `DATABASE_URL` variable.
+4. Add the `BASE_URL`, which is the full URL to reach the `public` folder of UDOIT. (i.e. https://udoit3.ciditools.com)
+5. Set `APP_LMS` to the name of your LMS.
+   * `canvas` if you are using the Canvas LMS.
+   * `d2l` if you are using the D2l Brightspace LMS.
+6. (Optional) You can change the default language for your entire UDOIT instance by overriding the `DEFAULT_LANG` variable. Currently supported languages are English (`en`) and Spanish (`es`).
 
 ## Database Setup
 While UDOIT is configured to use MySQL or MariaDB by default, Symfony can be configured to work with other databases as well. See the Symfony documentation for details.
@@ -102,4 +108,4 @@ For example, if you are setting this up on your local computer it may look like:
     https://udoit.local/lti/config
 
 ## Configuring Your LMS
-You will need to complete the steps in the INSTALL_CANVAS.md or INSTALL_D2L.md to configure UDOIT to work within your LMS.
+You will need to complete the steps in the [INSTALL_CANVAS.md](INSTALL_CANVAS.md) or [INSTALL_D2L.md](INSTALL_D2L.md) to configure UDOIT to work within your LMS.


### PR DESCRIPTION
Fixes #681

It also changes the default `APP_ENV` value since most people downloading this code will be using it on production rather than for development.