### PR TITLE
Bump url-parse to 1.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,8 @@
         "react-html-parser": "^2.0.2",
         "react-router-dom": "^5.2.0",
         "reactstrap": "^8.7.1"
+    },
+    "resolutions": {
+        "**/url-parse": "1.5.3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11679,7 +11679,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-parse@^1.4.3, url-parse@^1.5.1:
+url-parse@1.5.3, url-parse@^1.4.3, url-parse@^1.5.1:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.3.tgz#71c1303d38fb6639ade183c2992c8cc0686df862"
   integrity sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==


### PR DESCRIPTION
A previous update to this branch reverted the url-parse change because it was only done to the yarn.lock file, not the package.json.  This change properly resolves the package to 1.5.3.