### PR TITLE
Replace File References

### DIFF
--- a/assets/js/Components/FilesModal.js
+++ b/assets/js/Components/FilesModal.js
@@ -270,6 +270,12 @@ class FilesModal extends React.Component {
       return
     }
 
+    const userConfirmed = window.confirm(this.props.t('msg.confirmation'));
+
+    if (!userConfirmed) {
+      return;
+    }
+
     let api = new Api(this.props.settings)
     api.postFile(activeFile, this.state.replaceFileObj)
       .then((responsStr) => responsStr.json())

--- a/src/Lms/Canvas/CanvasApi.php
+++ b/src/Lms/Canvas/CanvasApi.php
@@ -173,12 +173,8 @@ class CanvasApi {
     public function apiDelete($url) {
         $lmsResponse = new LmsResponse();
 
-        if (strpos($url, 'https://') === false) {
-            $pattern = '/\/files\/\d+/';
-
-            preg_match($pattern, $url, $matches);
-    
-            $url = "https://" . $this->baseUrl . "/api/v1/" . $matches[0];
+        if (strpos($url, 'https://') === false) {    
+            $url = "https://{$this->baseUrl}/api/v1/{$url}";
         }
 
         $response = $this->httpClient->request('DELETE', $url);

--- a/translations/en.json
+++ b/translations/en.json
@@ -127,6 +127,7 @@
   "menu.full_rescan": "Force Full Rescan",
 
   "msg.no_permissions": "You do not have permission to access the specified course.",
+  "msg.confirmation": "Are you sure you want to replace this file? This action cannot be undone.",
   "msg.course_scanning": "Course scanning...",
   "msg.no_new_content": "Course scan complete. No new content found.",
   "msg.new_content": "Course scan complete. New content has been added.",
@@ -175,7 +176,7 @@
   "label.next_file": "Next File",
   "label.upload": "Upload",
   "label.replace": "Replace File",
-  "label.replace.desc": "Replace the current version of this file here.",
+  "label.replace.desc": "Replace the current version of this file here. This modal will replace all instances of the file in assignments, pages, modules, syllabus, quizzes and quiz questions. This action cannot be undone.",
   "label.loading": "Loading",
   "label.loading_reports": "Loading report history",
   "label.loading_users": "Loading users",


### PR DESCRIPTION
Presently, whenever a user attempts to replace a file using the file replacement modal, it only allows them to upload the new file to the files section and delete the previous version. However, the application does not account for references where the previous file may be used (assignments, pages, modules, etc...), and so the user ends up with a few broken links on their hands. This PR seeks to address this issue. The code in this pull request will replace all instances of the previous file in assignments, modules, wiki pages, syllabus, quizzes, and individual quiz questions, with the the new file. It also removes the deleting functionality to maintain links that the CanvasAPI does not permit us to change (announcements for example).