### PR TITLE
Updated message tray

### DIFF
--- a/assets/css/udoit4-theme.css
+++ b/assets/css/udoit4-theme.css
@@ -69,6 +69,8 @@ body {
 }
 
 #app-container {
+  position: relative;
+  overflow: hidden;
   margin: 0px 6px 6px 0px;
   padding: 0 1rem;
   border-radius: 16px;

--- a/assets/js/Components/App.js
+++ b/assets/js/Components/App.js
@@ -12,7 +12,7 @@ import { analyzeReport } from '../Services/Report'
 
 export default function App(initialData) {
 
-  const [messages, setMessages] = useState(initialData.messages || [])
+  const [nextMessage, setNextMessage] = useState('')
   const [untranslatedMessage, setUntranslatedMessage] = useState('')
   const [report, setReport] = useState(initialData.report || null)  
   const [settings, setSettings] = useState(initialData.settings || null)
@@ -206,12 +206,7 @@ export default function App(initialData) {
   }
 
   const addMessage = (msg) => {
-    setMessages([msg])
-    // setMessages(prevMessages => [...prevMessages, msg])
-  }
-
-  const clearMessages = () => {
-    setMessages([])
+    setNextMessage(msg)
   }
 
   const processServerError = (response) => {
@@ -414,8 +409,7 @@ export default function App(initialData) {
       <MessageTray
         t={t}
         settings={settings}
-        messages={messages}
-        clearMessages={clearMessages}
+        nextMessage={nextMessage}
       />
     </div>
   )

--- a/assets/js/Components/Widgets/Combobox.js
+++ b/assets/js/Components/Widgets/Combobox.js
@@ -419,7 +419,6 @@ export default function Combobox({
   const onOptionMouseDown = () => {
     // Clicking an option will cause a blur event,
     // but we don't want to perform the default keyboard blur action
-    console.log("Is there a blurring problem here?")
     // let containerEl = document.getElementById('combo-container-' + id)
     // if(!containerEl) {
     //   return

--- a/assets/js/Components/Widgets/Message.js
+++ b/assets/js/Components/Widgets/Message.js
@@ -17,6 +17,7 @@ export default function Message ({
 
   const ref = useRef()
   const [isPaused, setIsPaused] = useState(true)
+  const [isOpen, setIsOpen] = useState(false)
 
   useEffect(() => {
     const htmlElement = ref.current
@@ -25,12 +26,14 @@ export default function Message ({
     requestAnimationFrame(() => {
       htmlElement.style.transition = "transform 0.5s cubic-bezier(0.68, -0.55, 0.25, 1.35)"
       htmlElement.style.transform = "translateX(0)"
+      setIsOpen(true)
     });
 
     handleResume()
   }, []);
 
   const handleClose = () => {
+    setIsOpen(false)
     removeMessage(messageObject.id)
   }
 
@@ -61,7 +64,7 @@ export default function Message ({
     <div
       ref={ref}
       data-id={messageObject.id}
-      className={`messageItemContainer flex-column ${messageObject.severity}`}
+      className={`messageItemContainer flex-column ${messageObject.severity} ${isOpen ? 'open' : ''}`}
       role="alert"
       aria-live="polite"
       aria-atomic="true"
@@ -74,8 +77,6 @@ export default function Message ({
           </div>
           <div className="flex-column justify-content-center">
             {t(messageObject.message)}
-            <br />
-            {messageObject.id}
           </div>
         </div>
       <button

--- a/assets/js/Components/Widgets/Message.js
+++ b/assets/js/Components/Widgets/Message.js
@@ -1,0 +1,96 @@
+import React, { useState, useEffect, useRef } from 'react'
+import ProgressIcon from '../Icons/ProgressIcon'
+import FixedIcon from '../Icons/FixedIcon'
+import InfoIcon from '../Icons/InfoIcon'
+import SeverityIssueIcon from '../Icons/SeverityIssueIcon'
+import SeverityPotentialIcon from '../Icons/SeverityPotentialIcon'
+import CloseIcon from '../Icons/CloseIcon'
+
+export default function Message ({
+  t,
+  settings,
+  messageObject,
+  pauseTimer,
+  resumeTimer,
+  removeMessage
+}) {
+
+  const ref = useRef()
+  const [isPaused, setIsPaused] = useState(true)
+
+  useEffect(() => {
+    const htmlElement = ref.current
+    htmlElement.style.transform = "translateX(calc(100% + 20px))"
+
+    requestAnimationFrame(() => {
+      htmlElement.style.transition = "transform 0.5s cubic-bezier(0.68, -0.55, 0.25, 1.35)"
+      htmlElement.style.transform = "translateX(0)"
+    });
+
+    handleResume()
+  }, []);
+
+  const handleClose = () => {
+    removeMessage(messageObject.id)
+  }
+
+  const handlePause = () => {
+    setIsPaused(true)
+    pauseTimer(messageObject.id)
+  }
+
+  const handleResume = () => {
+
+    let tempTimer = settings?.user?.roles?.alert_timeout || "5000"
+    if (tempTimer === 'none') {
+      return
+    }
+    setIsPaused(false)
+    resumeTimer(messageObject.id)
+  }
+
+  const statusMap = {
+    'success': <FixedIcon className="icon-lg primary" alt="" />,
+    'info': <InfoIcon className="icon-lg color-info" alt="" />,
+    'error': <SeverityIssueIcon className="icon-lg color-issue" alt="" />,
+    'alert': <SeverityPotentialIcon className="icon-lg color-potential" alt="" />,
+    'progress': <ProgressIcon className="icon-lg udoit-suggestion spinner" alt="" />
+  }
+
+  return (
+    <div
+      ref={ref}
+      data-id={messageObject.id}
+      className={`messageItemContainer flex-column ${messageObject.severity}`}
+      role="alert"
+      aria-live="polite"
+      aria-atomic="true"
+      onMouseEnter={() => handlePause()}
+      onMouseLeave={() => handleResume()}
+      >
+        <div className="messageTrayItem flex-row gap-2">
+          <div className="flex-column justify-content-start">
+            {statusMap[messageObject.severity]}
+          </div>
+          <div className="flex-column justify-content-center">
+            {t(messageObject.message)}
+            <br />
+            {messageObject.id}
+          </div>
+        </div>
+      <button
+        className="flex-column justify-content-center closeButton"
+        onClick={() => handleClose()}
+        tabIndex="0"
+        aria-label={t('label.close_message')}
+        title={t('label.close_message')}>
+        <CloseIcon className="icon-sm text-color" />
+      </button>
+      { settings?.user?.roles?.alert_timeout !== 'none' && (
+        <div className="messageTrayAnimatedBorderContainer">
+          <div className={`messageTrayAnimatedBorder ${messageObject.id} ${messageObject.severity} ${!isPaused ? `ms${settings?.user?.roles?.alert_timeout}` : ''}`}/>
+        </div>
+      ) }
+    </div>
+  )
+}

--- a/assets/js/Components/Widgets/MessageTray.css
+++ b/assets/js/Components/Widgets/MessageTray.css
@@ -2,102 +2,110 @@
   position: absolute;
   top: 3rem;
   right: 1rem;
-  transform: translateX(calc(100% + 30px));
-  transition: transform 0.5s cubic-bezier(0.68, -0.55, 0.25, 1.35);
   z-index: 1000;
   box-sizing: border-box;
   width: calc(100% - 2rem);
   max-width: 400px;
-  background-color: var(--primary-color-light);
-  box-shadow: 0px 0px 3px var(--gray-dark);
 
-  &.open {
-    transform: translateX(0);
-  }
+  .messageItemContainer {
+    position: relative;
+    background-color: var(--primary-color-light);
+    box-shadow: 0px 0px 3px var(--gray-dark);
 
-  &.error {
-    border: 1px solid var(--issue-color);
-    background-color: var(--issue-color-light);
-  }
-
-  &.alert {
-    border: 1px solid var(--potential-color);
-    background-color: var(--potential-color-light);
-  }
-
-  &.success {
-    border: 1px solid var(--success-color);
-    background-color: var(--success-color-light);
-  }
-
-  &.info {
-    border: 1px solid var(--info-color);
-    background-color: var(--info-color-light);
-  }
-
-  &:hover {
-    .closeButton {
-      background-color: var(--white);
+    &:not(:first-child) {
+      margin-top: 1rem;
     }
-  }
-}
 
-.messageTray {
-  
-  padding: 1rem 2.75rem 1rem 1rem;
-  box-sizing: border-box;
-  font-size: .9em;
-  font-weight: 500;
-  color: var(--text-color)
-
-}
-
-.closeButton {
-  position: absolute;
-  top: .5rem;
-  right: .5rem;
-  padding: 0.15rem;
-  border-radius: 2rem;
-  background-color: transparent;
-}
-
-.messageTrayAnimatedBorderContainer {
-  width: 100%;
-  height: 3px;
-  display: flex;
-  justify-content: end;
-
-  .messageTrayAnimatedBorder {
-    width: 100%;
-    height: 100%;
+    &.open {
+      transform: translateX(0);
+    }
 
     &.error {
-      background-color: var(--issue-color);
+      border: 1px solid var(--issue-color);
+      background-color: var(--issue-color-light);
     }
 
     &.alert {
-      background-color: var(--potential-color);
+      border: 1px solid var(--potential-color);
+      background-color: var(--potential-color-light);
     }
 
     &.success {
-      background-color: var(--success-color);
+      border: 1px solid var(--success-color);
+      background-color: var(--success-color-light);
     }
 
     &.info {
-      background-color: var(--info-color);
+      border: 1px solid var(--info-color);
+      background-color: var(--info-color-light);
     }
 
-    &.ms5000 {
-      width: 0;
-      transition: width 5s linear;
+    &:hover {
+      .closeButton {
+        background-color: var(--white);
+      }
     }
-    &.ms10000 {
-      width: 0;
-      transition: width 10s linear;
+
+    .messageTrayItem {  
+      padding: 1rem 2.75rem 1rem 1rem;
+      box-sizing: border-box;
+      font-size: .9em;
+      font-weight: 500;
+      color: var(--text-color)
     }
-    &.ms20000 {
-      width: 0;
-      transition: width 20s linear;
+
+    .closeButton {
+      position: absolute;
+      top: .5rem;
+      right: .5rem;
+      padding: 0.15rem;
+      border-radius: 2rem;
+      background-color: transparent;
+    }
+  }
+
+  .messageTrayAnimatedBorderContainer {
+    width: 100%;
+    height: 3px;
+    display: flex;
+    justify-content: end;
+
+    .messageTrayAnimatedBorder {
+      width: 100%;
+      height: 100%;
+
+      &.error {
+        background-color: var(--issue-color);
+      }
+
+      &.alert {
+        background-color: var(--potential-color);
+      }
+
+      &.success {
+        background-color: var(--success-color);
+      }
+
+      &.info {
+        background-color: var(--info-color);
+      }
+
+      &.ms5000 {
+        width: 0;
+        transition: width 5s linear;
+      }
+      &.ms10000 {
+        width: 0;
+        transition: width 10s linear;
+      }
+      &.ms20000 {
+        width: 0;
+        transition: width 20s linear;
+      }
     }
   }
 }
+
+
+
+

--- a/assets/js/Components/Widgets/MessageTray.css
+++ b/assets/js/Components/Widgets/MessageTray.css
@@ -11,6 +11,8 @@
     position: relative;
     background-color: var(--primary-color-light);
     box-shadow: 0px 0px 3px var(--gray-dark);
+    transform: translateX(calc(100% + 20px));
+    transition: transform 0.5s cubic-bezier(0.68, -0.55, 0.25, 1.35);
 
     &:not(:first-child) {
       margin-top: 1rem;

--- a/assets/js/Components/Widgets/MessageTray.js
+++ b/assets/js/Components/Widgets/MessageTray.js
@@ -1,120 +1,162 @@
-import React, { useState, useEffect } from 'react'
-import ProgressIcon from '../Icons/ProgressIcon'
-import FixedIcon from '../Icons/FixedIcon'
-import InfoIcon from '../Icons/InfoIcon'
-import SeverityIssueIcon from '../Icons/SeverityIssueIcon'
-import SeverityPotentialIcon from '../Icons/SeverityPotentialIcon'
-import CloseIcon from '../Icons/CloseIcon'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import Message from './Message'
 
 import './MessageTray.css'
 
 export default function MessageTray ({
   t,
   settings,
-  messages,
-  clearMessages,
+  nextMessage
 }) {
 
-  const [isOpen, setIsOpen] = useState(false)
-  const [timerInt, setTimerInt] = useState(null)
-  const [localMessages, setLocalMessages] = useState([])
+  const [messages, setMessages] = useState([])
+  const [messageTimers, setMessageTimers] = useState([])
+  const [timerCounter, setTimerCounter] = useState(1)
+  const positions = useRef(new Map())
+  const containerRef = useRef(null)
 
-  useEffect(() => {
-    clearMessages()
-  }, [])
+  const createMessage = (newMessage) => {
+    if(!newMessage.message) {
+      return
+    }
+    const id = Date.now() + Math.random().toString().slice(2)
+    newMessage.id = id
+    setMessages(previousMessages => [...previousMessages, newMessage])
+  }
 
-  useEffect(() => {
-    let tempTimer = settings?.user?.roles?.alert_timeout || "5000"
-    if(timerInt) {
-      clearInterval(timerInt)
-      setTimerInt(null)
+  const removeMessage = (id) => {
+    const container = containerRef.current
+    if (!container) {
+      return
     }
-    if (messages.length > 0) {
-      setIsOpen(true)
-      setLocalMessages([...messages])
-      if (timerInt) {
-        clearInterval(timerInt)
-      }
-      if (tempTimer !== 'none') {
-        setTimerInt(setTimeout(() => {
-          handleClose()
-        }, tempTimer))
-      }
-    }
-    else {
-      setIsOpen(false)
-      setLocalMessages([])
-    }
-  }, [messages])
 
-  const handleClose = () => {
-    setIsOpen(false)
+    const el = container.querySelector(`[data-id="${id}"]`)
+    if(el) {
+      el.style.transform = "translateX(calc(100% + 30px))"
+      el.style.transition = "transform 0.5s cubic-bezier(0.68, -0.55, 0.25, 1.35)"
+    }
     setTimeout(() => {
-      clearMessages()
+      setMessages(existingMessages => existingMessages.filter(message => message.id !== id))
     }, 500)
   }
 
-  const pauseTimer = () => {
-    if (timerInt) {
-      clearInterval(timerInt)
-      setTimerInt(null)
-    }
-  }
-
-  const resumeTimer = () => {
-    let tempTimer = settings?.user?.roles?.alert_timeout || "5000"
-    if (tempTimer === 'none') {
+  /**
+   * The messages in the message tray usually have a time-out based on user settings. However, if a user
+   * moves the mouse over a message, the timer pauses and resets. HOWEVER, the setTimeout function will
+   * continue to run unless a clearInterval function with the timeout id is called.
+   * 
+   * I tried that first, mapping each message to the timer id, but when the timer DIDN'T get paused, I
+   * had an issue with React maintaining an internal state from when the timer was set, and wasn't able
+   * to save the timer id and have it still exist when the function the timer itself was calling got run.
+   * 
+   * The easiest workaround was to just create a counter (timerCounter) that increments every time a new
+   * timer is created. If a user mouses over and off a message multiple times, any number of timeouts may
+   * be created, but the messageTimers object will remember the most recent timer that was set for each
+   * message. All timeouts run to completion, but the message is only removed when the timer that finished
+   * matches the most recent timer that was set for a given message.
+   */
+  const resumeTimer = (messageId) => {
+    let tempTimerMs = settings?.user?.roles?.alert_timeout || "5000"
+    if (tempTimerMs === 'none') {
+      setMessageTimers(Object.assign({}, messageTimers, {[messageId]: null}) )
       return
     }
-    if (!timerInt && messages.length > 0) {
-      setTimerInt(setTimeout(() => {
-        handleClose()
-      }, tempTimer))
-    }
+
+    let tempMessageTimers = messageTimers
+    tempMessageTimers[messageId] = timerCounter
+    setMessageTimers(tempMessageTimers)
+    setTimeout(() => {
+      attemptClose(messageId, timerCounter)
+    }, tempTimerMs)
+    setTimerCounter(timerCounter + 1)
   }
 
-  const statusMap = {
-    'success': <FixedIcon className="icon-lg primary" alt="" />,
-    'info': <InfoIcon className="icon-lg color-info" alt="" />,
-    'error': <SeverityIssueIcon className="icon-lg color-issue" alt="" />,
-    'alert': <SeverityPotentialIcon className="icon-lg color-potential" alt="" />,
-    'progress': <ProgressIcon className="icon-lg udoit-suggestion spinner" alt="" />
+  const pauseTimer = (messageId) => {
+    if(messageTimers[messageId] !== null) {
+      clearTimeout(messageTimers[messageId])
+    }
+    let tempMessageTimers = messageTimers
+    tempMessageTimers[messageId] = null
+    setMessageTimers(tempMessageTimers)
   }
+
+  const attemptClose = (messageId, timerId) => {
+    if(messageTimers[messageId] !== timerId) {
+      return
+    }
+    removeMessage(messageId)
+  }
+
+  useEffect(() => {
+    createMessage(nextMessage)
+  }, [nextMessage])
+
+  // useLayoutEffect is for when you want to ensure the effect is processed BEFORE drawing to the screen.
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+
+    // In order to animate the list growing and shrinking as messages are added and removed, we'll be
+    // using the "FLIP" technique as explained here:
+    // https://medium.com/partoo/a-powerful-technique-for-making-animations-in-react-e91bbda5efd7
+
+    // FIRST: Get the starting ("first") positions of all relevant elements.
+    // If any animations have played before, this will already be stored in the `positions` state.
+
+    // LAST: Get the ending ("last") positions of all relevant elements.
+    const newPositions = new Map()
+    container.querySelectorAll("[data-id]").forEach(messageElement => {
+      newPositions.set(messageElement.dataset.id, messageElement.getBoundingClientRect())
+    })
+
+    // INVERT: Force the elements to stick to their old ("first") positions by inverting the change
+    // between the first and last positions.
+    newPositions.forEach((newBoundingRect, id) => {
+      const oldRect = positions.current.get(id)
+      if (!oldRect) return
+
+      const dy = oldRect.top - newBoundingRect.top
+
+      if (dy !== 0) {
+        const el = container.querySelector(`[data-id="${id}"]`)
+        el.style.transform = `translateX(0px) translateY(${dy}px)`
+        el.style.transition = "transform 0s"
+      }
+    })
+
+    // PLAY: Animate from the forced old position to the new position by removing the inversion.
+    requestAnimationFrame(() => {
+      newPositions.forEach((_, id) => {
+        const el = container.querySelector(`[data-id="${id}"]`)
+        if (!el) return
+
+        el.style.transition = "transform 300ms ease-in-out"
+        el.style.transform = ""
+      })
+    })
+
+    // Save new positions for next cycle
+    positions.current = newPositions
+
+  }, [messages])
 
   return (
     <div
-      className={`messageTrayContainer ${isOpen ? 'open' : ''} ${localMessages[0]?.severity}`} 
-      role="alert"
-      aria-live="polite"
-      aria-atomic="true"
-      onMouseEnter={pauseTimer}
-      onMouseLeave={resumeTimer}
-      >
-      <div className='messageTray flex-column'>
-        {localMessages.map((msg, i) => (
-          <div className='messageTrayItem flex-row gap-2' key={`msg${i}`}>
-            <div className="flex-column justify-content-start">
-              {statusMap[msg.severity]}
-            </div>
-            <div className="flex-column justify-content-center">
-              {t(msg.message)}
-            </div>
-          </div>
+      className='messageTrayContainer flex-column'
+      ref={containerRef} >
+        {messages.map((msg, i) => (
+          <Message
+            key={msg.id}
+            t={t}
+            settings={settings}
+            messageObject={msg}
+            pauseTimer={pauseTimer}
+            resumeTimer={resumeTimer}
+            removeMessage={removeMessage}
+          />
         ))}
-        <button
-          className="flex-column justify-content-center closeButton"
-          onClick={() => handleClose()}
-          tabIndex={isOpen ? '0' : '-1'}
-          aria-label={t('label.close_message')}
-          title={t('label.close_message')}>
-          <CloseIcon className="icon-sm text-color" />
-        </button>
-      </div>
-      { settings?.user?.roles?.alert_timeout !== 'none' && (
-        <div className="messageTrayAnimatedBorderContainer">
-          <div className={`messageTrayAnimatedBorder ${localMessages[0]?.severity} ${timerInt ? `ms${settings?.user?.roles?.alert_timeout}` : ''}`}/>
-        </div>
-      ) }
     </div>
   )
 }


### PR DESCRIPTION
Before, only one alert message could be displayed, and in another alert came through, the first alert would be overwritten. Now, multiple alerts can display on screen, each with its own timer and "close" button.

The easiest way to test this out is to change multiple settings on the Settings page or open another tab and switch between the UDOIT tab and the other a few times.

<img width="850" height="850" alt="image" src="https://github.com/user-attachments/assets/efc67359-e72b-4f63-8ecd-9158dae59838" />

Code-wise, this completely reworks the MessageTray component and adds the Message component for an individual message. The App.js code is edited to just send each message as it receives it directly to the MessageTray, where it is handled, instead of having a setMessages function at the App level.