### PR TITLE
Adds User-Agent headers to API requests. Needs testing in Dev.

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -119,6 +119,7 @@ class AuthController extends AbstractController
         $institution = $user->getInstitution();
         $code = $this->request->query->get('code');
         $clientSecret = $institution->getApiClientSecret();
+        $userAgent = 'UDOIT/' . !empty($_ENV['VERSION_NUMBER']) ? $_ENV['VERSION_NUMBER'] : '4.0.0';
 
         if (empty($clientSecret)) {
             $institution->encryptDeveloperKey();
@@ -133,6 +134,9 @@ class AuthController extends AbstractController
                 'redirect_uri'  => LmsUserService::getOauthRedirectUri(),
                 'client_secret' => $institution->getApiClientSecret(),
                 'code'          => $code,
+            ],
+            'headers' => [
+                'User-Agent' => $userAgent,
             ],
             'verify_host' => false,
             'verify_peer' => false,

--- a/src/Controller/LtiController.php
+++ b/src/Controller/LtiController.php
@@ -295,7 +295,12 @@ class LtiController extends AbstractController
         $httpClient = HttpClient::create();
         /* URL will be different for other LMSes */
         $url = $this->lmsApi->getLms()->getKeysetUrl();
-        $response = $httpClient->request('GET', $url);
+        $userAgent = 'UDOIT/' . (!empty($_ENV['VERSION_NUMBER']) ? $_ENV['VERSION_NUMBER'] : '4.0.0');
+        $response = $httpClient->request('GET', $url, [
+            'headers' => [
+                'User-Agent' => $userAgent,
+            ],
+        ]);
 
         $keys = $response->toArray();
         return $keys;

--- a/src/Lms/Canvas/CanvasApi.php
+++ b/src/Lms/Canvas/CanvasApi.php
@@ -25,6 +25,11 @@ class CanvasApi {
     public function apiGet(string $url, array $options = [], int $perPage = 100, ?LmsResponse $lmsResponse = null): LmsResponse
     {
         $links = [];
+        if(!isset($options['headers'])) {
+            $options['headers'] = [];
+        }
+        $userAgent = 'UDOIT/' . (!empty($_ENV['VERSION_NUMBER']) ? $_ENV['VERSION_NUMBER'] : '4.0.0');
+        $options['headers']['User-Agent'] = $userAgent;
 
         if (!$lmsResponse) {
             $lmsResponse = new LmsResponse();
@@ -82,6 +87,11 @@ class CanvasApi {
     public function apiPost($url, $options, $sendAuthorized = true)
     {
         $lmsResponse = new LmsResponse();
+        if(!isset($options['headers'])) {
+            $options['headers'] = [];
+        }
+        $userAgent = 'UDOIT/' . (!empty($_ENV['VERSION_NUMBER']) ? $_ENV['VERSION_NUMBER'] : '4.0.0');
+        $options['headers']['User-Agent'] = $userAgent;
 
         if (strpos($url, 'https://') === false) {
             $url = "https://{$this->baseUrl}/api/v1/{$url}";
@@ -113,6 +123,11 @@ class CanvasApi {
     {
         $fileResponse = $this->apiGet($url);
         $file = $fileResponse->getContent();
+        if(!isset($options['headers'])) {
+            $options['headers'] = [];
+        }
+        $userAgent = 'UDOIT/' . (!empty($_ENV['VERSION_NUMBER']) ? $_ENV['VERSION_NUMBER'] : '4.0.0');
+        $options['headers']['User-Agent'] = $userAgent;
 
         // TODO: handle failed call
 
@@ -121,8 +136,9 @@ class CanvasApi {
             'parent_folder_id' => $file['folder_id'],
             'content_type' => $file['content-type'],
         ];
+        $options['query'] = $endpointOptions;
 
-        $endpointResponse = $this->apiPost($options['postUrl'], ['query' => $endpointOptions], true);
+        $endpointResponse = $this->apiPost($options['postUrl'], $options, true);
         $endpointContent = $endpointResponse->getContent();
 
         $this->apiDelete($url);
@@ -144,6 +160,11 @@ class CanvasApi {
     public function apiPut($url, $options)
     {
         $lmsResponse = new LmsResponse();
+        if(!isset($options['headers'])) {
+            $options['headers'] = [];
+        }
+        $userAgent = 'UDOIT/' . (!empty($_ENV['VERSION_NUMBER']) ? $_ENV['VERSION_NUMBER'] : '4.0.0');
+        $options['headers']['User-Agent'] = $userAgent;
 
         if (strpos($url, 'https://') === false) {
             $url = "https://{$this->baseUrl}/api/v1/{$url}";
@@ -164,8 +185,13 @@ class CanvasApi {
         return $lmsResponse;
     }
 
-    public function apiDelete($url) {
+    public function apiDelete($url, $options = []) {
         $lmsResponse = new LmsResponse();
+        if(!isset($options['headers'])) {
+            $options['headers'] = [];
+        }
+        $userAgent = 'UDOIT/' . (!empty($_ENV['VERSION_NUMBER']) ? $_ENV['VERSION_NUMBER'] : '4.0.0');
+        $options['headers']['User-Agent'] = $userAgent;
 
         if (strpos($url, 'https://') === false) {
             $pattern = '/\/files\/\d+/';
@@ -175,8 +201,7 @@ class CanvasApi {
             $url = "https://" . $this->baseUrl . "/api/v1/" . $matches[0];
         }
 
-        $response = $this->httpClient->request('DELETE', $url);
-
+        $response = $this->httpClient->request('DELETE', $url, $options);
         $lmsResponse->setResponse($response);
 
         $content = $lmsResponse->getContent();

--- a/src/Services/LmsUserService.php
+++ b/src/Services/LmsUserService.php
@@ -62,6 +62,7 @@ class LmsUserService {
     {
         $refreshToken = $user->getRefreshToken();
         $institution = $user->getInstitution();;
+        $userAgent = 'UDOIT/' . !empty($_ENV['VERSION_NUMBER']) ? $_ENV['VERSION_NUMBER'] : '4.0.0';
 
         if (empty($refreshToken)) {
             return false;
@@ -74,6 +75,9 @@ class LmsUserService {
                 'redirect_uri'  => self::getOauthRedirectUri(),
                 'client_secret' => $institution->getApiClientSecret(),
                 'refresh_token' => $refreshToken,
+            ],
+            'headers' => [
+                'User-Agent' => $userAgent,
             ],
             'verify_host' => false,
             'verify_peer' => false,


### PR DESCRIPTION
Canvas has a new requirement that API Requests need to include a 'User-Agent' header or they will be rejected (see the [Instructure documentation here](https://community.instructure.com/en/discussion/658205/enforcing-user-agent-header-for-canvas-api-requests)). The documentation says it will "reject any HTTP requests that do not include a User-Agent header," so I added the header in question to every request I could find.

This may need some significant testing in Canvas -dev or -beta to make sure I didn't miss anything.