### PR TITLE
Removes code blocks for Lambda

### DIFF
--- a/src/Services/LmsFetchService.php
+++ b/src/Services/LmsFetchService.php
@@ -231,9 +231,9 @@ class LmsFetchService {
 
         // If we're using Equal Access Lambda, send all the requests to Lambda for the
         // reports at once and save them all into an array (which should be in the same order as the ContentItems)
-        if ($scanner == "equalaccess_lambda" && count($contentItems) > 0) {
-            $equalAccessReports = $this->asyncReport->postMultipleArrayAsync($contentItems);
-        }
+        // if ($scanner == "equalaccess_lambda" && count($contentItems) > 0) {
+        //     $equalAccessReports = $this->asyncReport->postMultipleArrayAsync($contentItems);
+        // }
 
         // Scan each update content item for issues
         /** @var \App\Entity\ContentItem $contentItem */
@@ -294,7 +294,7 @@ class LmsFetchService {
         }
 
         $scanner = $_ENV['ACCESSIBILITY_CHECKER'];
-        if ($scanner == 'equalaccess_lambda' || $scanner == 'equalaccess_local') {
+        if ($scanner == 'equalaccess_lambda' || $scanner == 'equalaccess_local' || $scanner == 'equalaccess') {
           $issueType = $this->equalAccess->getIssueType($issue->getMetadata());
           if($issueType == 'pass') {
             // If the issue is a pass, we don't create an issue for it
@@ -324,7 +324,7 @@ class LmsFetchService {
         $issueType = self::ISSUE_TYPE_ERROR;
 
         $scanner = $_ENV['ACCESSIBILITY_CHECKER'];
-        if ($scanner == 'equalaccess_lambda' || $scanner == 'equalaccess_local') {
+        if ($scanner == 'equalaccess_lambda' || $scanner == 'equalaccess_local' || $scanner == 'equalaccess') {
           $issueType = $this->equalAccess->getIssueType($issue->metadata);
         }
 

--- a/src/Services/ScannerService.php
+++ b/src/Services/ScannerService.php
@@ -60,39 +60,29 @@ class ScannerService {
                 $phpAlly = new PhpAllyService($htmlService, $util);
                 $report = $phpAlly->scanContentItem($contentItem);
             }
-            else if ($scanner == 'equalaccess_local') {
+            else if ($scanner == 'equalaccess_local' || $scanner == 'equalaccess_lambda' || $scanner == 'equalaccess') {
                 $equalAccess = new EqualAccessService();
-
-                // $document = $this->getDomDocument($contentItem->getBody());
-
-                // $htmlContent = $document->saveHTML();
-                // $totalLength = strlen($htmlContent);
-
-                // $bodyElements = $document->getElementsByTagName('body');
-                // if ($bodyElements->length > 0) {
-                //     $printOutput->writeln("Body found with children: " . $bodyElements->item(0)->childNodes->length);
-                // }
 
                 $localService = new LocalApiAccessibilityService();
                 $json = $localService->scanContentItem($contentItem);
                 $report = $equalAccess->generateReport($json);
             }
-            else if ($scanner == 'equalaccess_lambda') {
-                $equalAccess = new EqualAccessService();
-                //$document = $this->getDomDocument($contentItem->getBody());
+            // else if ($scanner == 'equalaccess_lambda') {
+            //     $equalAccess = new EqualAccessService();
+            //     //$document = $this->getDomDocument($contentItem->getBody());
 
-                if (!$scannerReport) {
-                    // Report is null, we need to call the lambda function for a single page most likely
-                    // $this->logToServer("null $scannerReport!");
-                    $asyncReport = new AsyncEqualAccessReport();
-                    $json = $asyncReport->postSingleAsync($contentItem);
-                    $report = $equalAccess->generateReport($json);
-                }
-                else {
-                    // We already have the report, all we have to do is generate the UDOIT report
-                    $report = $equalAccess->generateReport($scannerReport);
-                }
-            }
+            //     if (!$scannerReport) {
+            //         // Report is null, we need to call the lambda function for a single page most likely
+            //         // $this->logToServer("null $scannerReport!");
+            //         $asyncReport = new AsyncEqualAccessReport();
+            //         $json = $asyncReport->postSingleAsync($contentItem);
+            //         $report = $equalAccess->generateReport($json);
+            //     }
+            //     else {
+            //         // We already have the report, all we have to do is generate the UDOIT report
+            //         $report = $equalAccess->generateReport($scannerReport);
+            //     }
+            // }
             else {
                 // Unknown scanner set in environment, should return error...
                 throw new \Exception("Unknown scanner type!");


### PR DESCRIPTION
Dirty fix to make the equalAccess scanner always do the same thing regardless of equalAccess scanner ENV variable.