### PR TITLE
PHP scanner fixes, plus quick layout tweaks that were lost in the merge.

### DIFF
--- a/assets/css/udoit4-theme.css
+++ b/assets/css/udoit4-theme.css
@@ -192,6 +192,11 @@
     font-weight: 600;
     line-height: normal;
     color: var(--text-color);
+
+    &:focus {
+      outline: 2px solid var(--focus-color);
+      outline-offset: 3px;
+    }
   }
 
   .pageTitle {
@@ -231,6 +236,17 @@
     }
   }
 
+  a {
+    color: var(--link-color);
+    font-weight: 300;
+
+    &:focus {
+      outline: 2px solid var(--focus-color);
+      outline-offset: 3px;
+      border-radius: 2px;
+    }
+  }
+  
   button {
     font-family: var(--heading-font-family);
     padding: .5rem 1rem;
@@ -559,6 +575,7 @@
       h2 {
         line-height: normal;
         align-self: center;
+        margin: 0;
       }
 
       .close-icon {

--- a/assets/js/Components/FixIssuesPage.js
+++ b/assets/js/Components/FixIssuesPage.js
@@ -822,16 +822,11 @@ export default function FixIssuesPage({
     setLiveUpdateToggle(!liveUpdateToggle)
   }
 
-  const isDialogOpen = () => {
-    const dialog = document.getElementById(dialogId)
-    return dialog && dialog.open
-  }
-
   const openDialog = () => {
     setWidgetState(WIDGET_STATE.FIXIT)
 
     const dialog = document.getElementById(dialogId)
-    if(dialog) {
+    if(dialog && !dialog.open) {
       dialog.showModal()
 
       const title = dialog.querySelector('#dialog-title')

--- a/assets/js/Components/SettingsPage.css
+++ b/assets/js/Components/SettingsPage.css
@@ -1,91 +1,83 @@
 @layer udoit-component {
 
-  h2 {
-    margin: 0 0 .5rem 0;
-  }
+  .settings-page-container {
 
-  a {
-    color: var(--link-color);
-    font-weight: 300;
-
-    &:focus {
-      outline: 2px solid var(--focus-color);
-      outline-offset: 3px;
-      border-radius: 2px;
-    }
-  }
-
-  .page-container {
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-    width: 100%;
-    flex-wrap: wrap;
-    padding-block-end: 1rem;
-    justify-content: center;
-
-    .settings-column {
-      display: flex;
-      flex-direction: column;
-      flex: 1 1 auto;
-      width: 60%;
-      max-width: 50em;
-
-      .settings-container {
-        padding: 1.5rem;
-        height: fit-content;
-
-        .settings-row {
-          display: flex;
-          flex-direction: row;
-          gap: .5rem;
-          justify-content: space-between;
-          flex-wrap: wrap;
-          align-items: center;
-          margin: .5rem 0;
-
-          label {
-            color: var(--text-secondary-color);
-          }
-        }
-
-        .divider {
-          border-top: 1px solid var(--border-color);
-          margin: 1.5rem -1.5rem;
-        }
-
-        .combo-container {
-          width: 18em;
-          max-width: 100%;
-        }
-      }
+    h2 {
+      margin: 0 0 .5rem 0;
     }
 
-    .about-column {
+    .page-container {
       display: flex;
-      flex-direction: column;
+      flex-direction: row;
       gap: 1rem;
-      width: 60%;
-      max-width: 50em;
-      flex: 1 1;
+      width: 100%;
+      flex-wrap: wrap;
+      padding-block-end: 1rem;
       justify-content: center;
 
-      .callout-container {
-        padding: 1.5rem;
-        flex: 1 1;
-        box-sizing: content-box;
-        min-width: 25rem;
-        max-width: 100%;
-        height: fit-content;
+      .settings-column {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        width: 60%;
+        max-width: 50em;
 
-        .udoit-logo {
-          width: 100%;
-          max-width: 150px;
-          margin: 0;
+        .settings-container {
+          padding: 1.5rem;
+          height: fit-content;
+
+          .settings-row {
+            display: flex;
+            flex-direction: row;
+            gap: .5rem;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            align-items: center;
+            margin: .5rem 0;
+
+            label {
+              color: var(--text-secondary-color);
+            }
+          }
+
+          .divider {
+            border-top: 1px solid var(--border-color);
+            margin: 1.5rem -1.5rem;
+          }
+
+          .combo-container {
+            width: 18em;
+            max-width: 100%;
+          }
         }
+      }
 
-        .version-number {
-          margin-top: -.5rem;  
+      .about-column {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        width: 60%;
+        max-width: 50em;
+        flex: 1 1;
+        justify-content: center;
+
+        .callout-container {
+          padding: 1.5rem;
+          flex: 1 1;
+          box-sizing: content-box;
+          min-width: 25rem;
+          max-width: 100%;
+          height: fit-content;
+
+          .udoit-logo {
+            width: 100%;
+            max-width: 150px;
+            margin: 0;
+          }
+
+          .version-number {
+            margin-top: -.5rem;  
+          }
         }
       }
     }

--- a/assets/js/Components/SettingsPage.js
+++ b/assets/js/Components/SettingsPage.js
@@ -157,7 +157,7 @@ export default function SettingsPage({
 
         <div className="callout-container flex-column gap-2">
           <h2>{t('settings.title.disclaimer')}</h2>
-          <p className="m=0">{t('settings.text.disclaimer')}</p>
+          <p className="m-0">{t('settings.text.disclaimer')}</p>
         </div>
       </div>
     </div>

--- a/src/Controller/SyncController.php
+++ b/src/Controller/SyncController.php
@@ -81,14 +81,14 @@ class SyncController extends ApiController
             $reportArr['contentItems'] = $course->getContentItems();
             $reportArr['contentSections'] = $lmsFetch->getCourseSections($course, $user);
 
-            $reportArr['instructors'] = $this->getInstructorNamesForCourse(
-            $course,
-            $user,
-            $courseUserRepo,
-            $userRepo,
-            $em,
-            $lmsApi
-            );
+            // $reportArr['instructors'] = $this->getInstructorNamesForCourse(
+            //     $course,
+            //     $user,
+            //     $courseUserRepo,
+            //     $userRepo,
+            //     $em,
+            //     $lmsApi
+            // );
 
             $response->setData($reportArr);
 

--- a/src/Lms/Canvas/CanvasLms.php
+++ b/src/Lms/Canvas/CanvasLms.php
@@ -352,6 +352,7 @@ class CanvasLms implements LmsInterface {
     // Get content from Canvas and update content items
     public function updateCourseContent(Course $course, User $user, $force = false): array
     {
+        $output = new ConsoleOutput();
         $this->contentItemList = [];
         $urls = $this->getCourseContentUrls($course->getLmsCourseId());
         $apiDomain = $this->getApiDomain($user);


### PR DESCRIPTION
After merging everything in, my local testing had a few issues:

- The scanner stopped working, and sent a 500 error. The issue was that the `$consoleOutput` variable was undefined, and that a bunch of imports on the scan function weren't included (I've just commented out the instructor list for the moment).
- Various styling issues didn't come across cleanly. Fixed a handful.