### PR TITLE
Rework for the Barriers and Files full-screen modal popups.

### DIFF
--- a/assets/css/udoit4-theme.css
+++ b/assets/css/udoit4-theme.css
@@ -536,8 +536,8 @@
     outline: 2px solid var(--focus-color);
   }
 
-
-  dialog {
+  dialog,
+  div[role="dialog"] {
     width: 90vw;
     max-width: 50em;
     overflow: hidden;
@@ -545,7 +545,6 @@
     border: none;
     border-radius: var(--window-radius);
     padding: 0;
-    background-color: var(--white);
     z-index: 100;
     box-shadow: 0 0 10px var(--shadow-color);
 
@@ -554,6 +553,23 @@
       max-width: 95vw;
       height: 95vh;
       max-height: 95vh;
+      position: fixed;
+      top: 2vh;
+    }
+
+    &::before {
+      content: "";
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background-color: var(--backdrop-color);
+      z-index: -1;
+    }
+
+    > * {
+      background-color: var(--white);
     }
 
     .dialog-header,
@@ -1304,6 +1320,10 @@
     font-size: 0.9em;
     overflow-wrap: anywhere;
     cursor: pointer;
+  }
+
+  .hidden {
+    display: none !important;
   }
 }
 

--- a/assets/js/Components/App.js
+++ b/assets/js/Components/App.js
@@ -41,6 +41,7 @@ export default function App(initialData) {
   const [sessionIssues, setSessionIssues] = useState({})
   const [sessionFiles, setSessionFiles] = useState({})
   const [welcomeClosed, setWelcomeClosed] = useState(false)
+  const [modalActive, setModalActive] = useState(false)
 
   // `t` is used for text/translation. It will return the translated string if it exists
   // in the settings.labels object.
@@ -381,10 +382,10 @@ export default function App(initialData) {
             <Header
               t={t}
               settings={settings}
-              hasNewReport={hasNewReport}
+              modalActive={modalActive}
               navigation={navigation}
-              syncComplete={syncComplete}
               handleNavigation={handleNavigation}
+              syncComplete={syncComplete}
              />
 
             <main role="main" id="main-content">
@@ -416,6 +417,7 @@ export default function App(initialData) {
                   sessionIssues={sessionIssues}
                   updateSessionIssue={updateSessionIssue}
                   processServerError={processServerError}
+                  setModalActive={setModalActive}
                 />
               }
               {('reviewFiles' === navigation) &&
@@ -432,6 +434,7 @@ export default function App(initialData) {
                   sessionFiles={sessionFiles}
                   updateSessionFiles={updateSessionFiles}
                   processServerError={processServerError}
+                  setModalActive={setModalActive}
                 />
               }
               {('reports' === navigation) &&

--- a/assets/js/Components/FixIssuesPage.js
+++ b/assets/js/Components/FixIssuesPage.js
@@ -7,7 +7,7 @@ import FixIssuesContentPreview from './Widgets/FixIssuesContentPreview'
 import LeftArrowIcon from './Icons/LeftArrowIcon'
 import RightArrowIcon from './Icons/RightArrowIcon'
 import CloseIcon from './Icons/CloseIcon'
-import { FORM_CLASSIFICATIONS, formFromIssue, formNameFromRule, formNames } from '../Services/Ufixit'
+import { formNameFromRule } from '../Services/Ufixit'
 import * as Html from '../Services/Html'
 import Api from '../Services/Api'
 
@@ -34,14 +34,14 @@ export default function FixIssuesPage({
   initialSeverity = '',
   initialSearchTerm = '',
   contentItemCache,
-  addContentItemToCache,
   report,
   sections,
   processNewReport,
   addMessage,
   sessionIssues,
   updateSessionIssue,
-  processServerError
+  processServerError,
+  setModalActive
 })
 {
 
@@ -66,9 +66,10 @@ export default function FixIssuesPage({
 
   const WIDGET_STATE = settings.WIDGET_STATE
 
-  const dialogId = "issue-dialog"
+  const dialogId = "udoit-issue-dialog"
 
   const [activeIssue, setActiveIssue] = useState(null)
+  const [mostRecentIssueId, setMostRecentIssueId] = useState(null)
   const [tempActiveIssue, setTempActiveIssue] = useState(null)
   const [activeContentItem, setActiveContentItem] = useState(null)
   const [tempActiveContentItem, setTempActiveContentItem] = useState(null)
@@ -250,6 +251,39 @@ export default function FixIssuesPage({
     }
   }, [])
 
+  const handleEscapeKey = (e) => {
+    if(e.key === 'Escape' && widgetState === WIDGET_STATE.FIXIT) {
+      e.preventDefault()
+      closeDialog()
+    }
+  }
+
+  // Pull focus into the dialog when it opens, and return focus to the most recently clicked issue when it closes
+  useEffect(() => {
+    if(widgetState === WIDGET_STATE.FIXIT) {
+      const dialog = document.getElementById(dialogId)
+      if (dialog) {
+        dialog.addEventListener('keydown', handleEscapeKey)
+        const title = dialog.querySelector('#ufixit-dialog-title')
+        if(title) {
+          title.focus()
+        }
+      }
+    }
+    else if(widgetState === WIDGET_STATE.LIST) {
+      if(mostRecentIssueId) {
+        const issueElement = document.getElementById(`issue-item-${mostRecentIssueId}`)
+        if(issueElement) {
+          issueElement.focus() 
+        }
+        const dialog = document.getElementById(dialogId)
+        if (dialog) {
+          dialog.removeEventListener('keydown', handleEscapeKey)
+        }
+      }
+    }
+  }, [widgetState])
+
   // When the filters or search term changes, update the filtered issues list
   useEffect(() => {
 
@@ -350,9 +384,14 @@ export default function FixIssuesPage({
       return
     }
   
-    setWidgetState(settings.WIDGET_STATE.FIXIT)
-    const activeIssueClone = JSON.parse(JSON.stringify(activeIssue))
+    setMostRecentIssueId(activeIssue.id)
+    
+    // We ONLY want this to trigger events on a real change.
+    if(widgetState !== WIDGET_STATE.FIXIT) {
+      openDialog()
+    }
 
+    const activeIssueClone = JSON.parse(JSON.stringify(activeIssue))
     activeIssueClone.issueData.initialHtml = Html.getIssueHtml(activeIssueClone.issueData)
     setTempActiveIssue(activeIssueClone)
     
@@ -365,7 +404,6 @@ export default function FixIssuesPage({
       setActiveContentItem(null)
     }
     setShowLearnMore(false)
-    openDialog()
 
   }, [activeIssue])
 
@@ -824,26 +862,13 @@ export default function FixIssuesPage({
 
   const openDialog = () => {
     setWidgetState(WIDGET_STATE.FIXIT)
-
-    const dialog = document.getElementById(dialogId)
-    if(dialog && !dialog.open) {
-      dialog.showModal()
-
-      const title = dialog.querySelector('#dialog-title')
-      if(title) {
-        title.focus()
-      }
-    }
+    setModalActive(true)
   }
 
   const closeDialog = () => {
     setWidgetState(WIDGET_STATE.LIST)
+    setModalActive(false)
     setActiveIssue(null)
-
-    const dialog = document.getElementById(dialogId)
-    if(dialog) {
-      dialog.close()
-    }
   }
 
   return (
@@ -851,7 +876,10 @@ export default function FixIssuesPage({
       { widgetState === settings.WIDGET_STATE.LOADING ? (
         <></>
       ) : (
-        <>
+        <div
+          inert={widgetState === WIDGET_STATE.FIXIT ? "inert" : undefined}
+          aria-hidden={widgetState === WIDGET_STATE.FIXIT}
+          >
           <h1 className="pageTitle">{t('barriers.title')}</h1>
           <p className="pageSubtitle">{t('barriers.subtitle')}</p>
 
@@ -873,12 +901,19 @@ export default function FixIssuesPage({
             groupedList={groupedList}
             setActiveIssue={setActiveIssue}
           />
-        </>
+        </div>
       ) }
-      <dialog id={dialogId} className="dialog-full-screen" onClose={closeDialog} aria-labelledby="dialog-title">
+      <div
+        id={dialogId}
+        role="dialog"
+        aria-modal="true"
+        className={`dialog-full-screen ${widgetState === WIDGET_STATE.FIXIT ? 'open' : 'hidden'}`}
+        onClose={closeDialog}
+        aria-labelledby="ufixit-dialog-title"
+        >
         <div className="flex-column h-100">
           <div className="dialog-header">
-            <h2 id="dialog-title" tabIndex="-1">{tempActiveIssue?.formLabel}</h2>
+            <h2 id="ufixit-dialog-title" tabIndex="-1">{tempActiveIssue?.formLabel}</h2>
             <CloseIcon
               onClick={closeDialog}
               onKeyDown={(e) => {
@@ -984,7 +1019,7 @@ export default function FixIssuesPage({
             </div>
           </div>
         </div>
-      </dialog>
+      </div>
     </>
   )
 }

--- a/assets/js/Components/Header.js
+++ b/assets/js/Components/Header.js
@@ -13,6 +13,7 @@ import './Header.css'
 export default function Header({
   t,
   settings,
+  modalActive,
   navigation,
   handleNavigation,
   syncComplete
@@ -76,7 +77,7 @@ export default function Header({
 
   /* CSS-Only Responsive Mobile menu based on: https://blog.logrocket.com/create-responsive-mobile-menu-css-without-javascript/ */
   return (
-    <header role="banner">
+    <header role="banner" inert={modalActive ? "inert" : undefined} aria-hidden={!modalActive}>
       <a className="skip-link" href="#main-content">{t('menu.nav.skip_to_main')}</a>
       <img alt={t('alt.UDOIT')} src={settings?.user?.roles?.dark_mode ? UDOITLogoDark : UDOITLogo}></img>
       <input

--- a/assets/js/Components/ReviewFilesPage.js
+++ b/assets/js/Components/ReviewFilesPage.js
@@ -43,7 +43,8 @@ export default function ReviewFilesPage({
   processNewReport,
   addMessage,
   sessionFiles,
-  updateSessionFiles
+  updateSessionFiles,
+  setModalActive
 })
 {
 
@@ -59,7 +60,7 @@ export default function ReviewFilesPage({
 
   const WIDGET_STATE = settings.WIDGET_STATE
 
-  const dialogId = "file-dialog"
+  const dialogId = "udoit-file-dialog"
 
   const headers = [
     { id: "name", text: t('fix.label.file_name') },
@@ -87,6 +88,7 @@ export default function ReviewFilesPage({
   const [unfilteredFiles, setUnfilteredFiles] = useState([])
   const [filteredFiles, setFilteredFiles] = useState([])
   const [widgetState, setWidgetState] = useState(WIDGET_STATE.LOADING)
+  const [mostRecentFileId, setMostRecentFileId] = useState(null)
 
   // Form States
   const [markAsReviewed, setMarkAsReviewed] = useState(false)
@@ -175,7 +177,7 @@ export default function ReviewFilesPage({
     let tempRows = []
     filteredFiles.forEach((tempFile) => {
       tempRows.push({
-        id: tempFile.id,
+        id: `udoit-file-${tempFile.id}`,
         name: tempFile.contentTitle ? { value: tempFile.contentTitle, display: getFileNameDisplay(tempFile)} : t('label.unknown'),
         type: tempFile.fileData.fileType ? { value: tempFile.fileData.fileType, display: getFileTypeDisplay(tempFile.fileData.fileType)}: t('label.mime.unknown'),
         date: tempFile.fileData.updated ? { value: tempFile.fileData.updated, display: Text.getReadableDateTime(tempFile.fileData.updated)} : t('label.unknown'),
@@ -333,6 +335,13 @@ export default function ReviewFilesPage({
     setIsDisabled(tempIsDisabled)
   }, [sessionFiles])
 
+  const handleEscapeKey = (e) => {
+    if(e.key === 'Escape' && widgetState === WIDGET_STATE.FIXIT) {
+      e.preventDefault()
+      closeDialog()
+    }
+  }
+
   useEffect(() => {
     if(showLearnMore) {
       document.getElementById('btn-learn-more-close')?.focus()
@@ -341,6 +350,32 @@ export default function ReviewFilesPage({
       document.getElementById('btn-learn-more-open')?.focus()
     }
   }, [showLearnMore])
+
+// Pull focus into the dialog when it opens, and return focus to the most recently clicked issue when it closes
+  useEffect(() => {
+    if(widgetState === WIDGET_STATE.FIXIT) {
+      const dialog = document.getElementById(dialogId)
+      if (dialog) {
+        dialog.addEventListener('keydown', handleEscapeKey)
+        const title = dialog.querySelector('#ufixit-dialog-title')
+        if(title) {
+          title.focus()
+        }
+      }
+    }
+    else if(widgetState === WIDGET_STATE.LIST) {
+      if(mostRecentFileId) {
+        const fileElement = document.getElementById(`udoit-file-${mostRecentFileId}`)
+        if(fileElement) {
+          fileElement.focus() 
+        }
+        const dialog = document.getElementById(dialogId)
+        if (dialog) {
+          dialog.removeEventListener('keydown', handleEscapeKey)
+        }
+      }
+    }
+  }, [widgetState])
 
 
   const isDialogOpen = () => {
@@ -351,21 +386,13 @@ export default function ReviewFilesPage({
 
   const openDialog = () => {
     setWidgetState(WIDGET_STATE.FIXIT)
-
-    const dialog = document.getElementById(dialogId)
-    if(dialog) {
-      dialog.showModal()
-    }
+    setModalActive(true)
   }
 
   const closeDialog = () => {
     setWidgetState(WIDGET_STATE.LIST)
+    setModalActive(false)
     setActiveIssue(null)
-
-    const dialog = document.getElementById(dialogId)
-    if(dialog) {
-      dialog.close()
-    }
   }
 
   const getFileTypeDisplay = (fileType) => {
@@ -885,6 +912,7 @@ const getSectionPostOptions = (newFile, sectionReferences) => {
     }
 
     setActiveIssue(filteredFiles[filteredFileIndex])
+    setMostRecentFileId(fileId)
     openDialog()
   }
 
@@ -902,6 +930,7 @@ const getSectionPostOptions = (newFile, sectionReferences) => {
     else if (newIndex >= filteredFiles.length) {
       newIndex = 0
     }
+    setMostRecentFileId(filteredFiles[newIndex].id)
     setActiveIssue(filteredFiles[newIndex])
   }
 
@@ -929,7 +958,10 @@ const getSectionPostOptions = (newFile, sectionReferences) => {
       { widgetState === WIDGET_STATE.LOADING ? (
         <></>
       ) : (
-        <>
+        <div
+          inert={widgetState === WIDGET_STATE.FIXIT ? "inert" : undefined}
+          aria-hidden={widgetState === WIDGET_STATE.FIXIT}
+          >
           <h1 className="pageTitle">{t('files.title')}</h1>
           <p className="pageSubtitle">{t('files.subtitle')}</p>
 
@@ -962,12 +994,19 @@ const getSectionPostOptions = (newFile, sectionReferences) => {
               </div>
             )}
           </div>
-        </>
+        </div>
       )}
-      <dialog id={dialogId} className="dialog-full-screen" onClose={closeDialog}>
+      <div
+        id={dialogId}
+        role="dialog"
+        aria-modal="true"
+        className={`dialog-full-screen ${widgetState === WIDGET_STATE.FIXIT ? 'open' : 'hidden'}`}
+        onClose={closeDialog}
+        aria-labelledby="ufixit-dialog-title"
+        >
         <div className='flex-column h-100'>
           <div className='dialog-header'>
-            <h2>{t(`form.file.title`)}</h2>
+            <h2 id="ufixit-dialog-title" tabIndex="-1">{t(`form.file.title`)}</h2>
             <CloseIcon onClick={closeDialog} onKeyDown={(e) => e.key == "Enter" ? closeDialog() : ""} className="close-icon icon-lg" tabIndex="0" alt={t('fix.button.close')} title={t('fix.button.close')} />
           </div>
            <div className="dialog-content">
@@ -1049,7 +1088,7 @@ const getSectionPostOptions = (newFile, sectionReferences) => {
               </button>
           </div>
         </div>
-      </dialog>
+      </div>
     </>
   )
 }

--- a/assets/js/Components/Widgets/FixIssuesList.js
+++ b/assets/js/Components/Widgets/FixIssuesList.js
@@ -99,6 +99,7 @@ export default function FixIssuesList({
                 { group.issues.map((issue, j) => {
                   return (
                     <div
+                      id={`issue-item-${issue.id}`}
                       className="ufixit-list-item flex-row justify-content-between gap-3"
                       key={j}
                       onClick={() => setActiveIssue(issue)}

--- a/assets/js/Components/Widgets/SortableTable.js
+++ b/assets/js/Components/Widgets/SortableTable.js
@@ -204,6 +204,7 @@ export default function SortableTable({
               const isRowClickable = !!row.onClick;
               return (
                 <tr
+                  id={row.id ? row.id : `row${index}`}
                   key={`row${index}`}
                   className={isRowClickable ? 'clickable' : ''}
                   onClick={isRowClickable ? row.onClick : undefined}


### PR DESCRIPTION
Before, when selecting an item the Barriers and Files screens, there was a full-screen `<dialog>` element where fixing all the issues happened. But using a `<dialog>` caused a number of issues:

1. Any other element in the main area was automatically hidden underneath the dialog. This meant that the notification popup (`MessageTray.js`) became invisible. So all of the "Content has been successfully saved." or "Error: ..." messages weren't available exactly when they needed to be.
2. OTHER dialogs didn't work inside them. Two notable examples are the `InfoPopover.js` element (Elias' `i` icon with information that shows up afterward) and the code editor widget inside of the TinyMCE editor.

So I've made the full screen dialog just a `<div>`, but with the right aria attributes to make screen readers THINK that it's a normal `<dialog>`. As far as I can tell, all normal keyboard, screen reader, and mouse interactions still work the same.