### PR TITLE
Quickfix file state change

### DIFF
--- a/assets/js/Components/Forms/FileForm.js
+++ b/assets/js/Components/Forms/FileForm.js
@@ -182,6 +182,12 @@ export default function FileForm ({
       setMarkAsReviewed(false)
       return
     }
+    else {
+      setMarkRevert(false)
+      setMarkAsReviewed(false)
+      setMarkDelete(false)
+      return
+    }
   }
 
   const removeUploadedFile = () => {


### PR DESCRIPTION
If clicked on "Keep Current File" the first thing in the file form, the state never changed. Fixed it so when clicking a different option changes state properly. 