### PR TITLE
Fix for APP_ENV=dev missing dependencies when building

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,12 +56,7 @@ We provide a fast and simple way of setting up a local UDOIT instance through Do
 
 #### 2. (Optional) Install the Necessary PHP Dependencies for Dev Environment
 
-UDOIT uses Composer to install PHP dependencies. If your `APP_ENV` is set to `prod`, UDOIT will handle this for you. However, if it is set to `dev`, you may need some additional dependencies.
-
-You can set them up by running the following command:
-```
-docker compose -f docker-compose.nginx.yml run composer composer install
-```
+UDOIT uses Composer to install PHP dependencies. Running the following command will handle installing the dependencies for you.
 
 #### 3. Build the Containers
 

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -52,7 +52,16 @@ services:
       build:
         context: ./build/nginx
         dockerfile: Dockerfile.composer
-      command: "composer install --no-dev --no-interaction --no-progress --optimize-autoloader"
+      command: >
+        sh -c '
+          if [ "$APP_ENV" = "dev" ]; then
+            echo "composer install (dev)" &&
+            composer install --no-interaction --no-progress --optimize-autoloader;
+          else
+            echo "composer install (prod)" &&
+            composer install --no-dev --no-interaction --no-progress --optimize-autoloader;
+          fi
+        '
       volumes:
         - ./:/app
       env_file:


### PR DESCRIPTION
Setting `APP_ENV=dev` in `.env` will stop UDOIT from correctly running because the development dependencies aren't being built in the `composer` container (since by default, we're running `composer install --no-dev --no-interaction --no-progress --optimize-autoloader`, which doesn't include dev dependencies). 

This introduces an if statement in the composer command to remove `--no-dev` when `APP_ENV=dev`.