### PR TITLE
Quickfix: PHP 8.5 image builds properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - quickfix-dockerfile-image-build
       - 'stable/*'
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - quickfix-dockerfile-image-build
       - 'stable/*'
 
 env:

--- a/build/nginx/Dockerfile.build
+++ b/build/nginx/Dockerfile.build
@@ -7,7 +7,6 @@ RUN apt-get update -y \
 ENV PHP_CPPFLAGS="$PHP_CPPFLAGS -std=c++17"
 
 RUN docker-php-ext-install pdo_mysql gd pdo \
-    && docker-php-ext-install opcache \
     && apt-get install libicu-dev -y \
     && docker-php-ext-configure intl \
     && docker-php-ext-install intl \


### PR DESCRIPTION
Due to the change from php 8.4 to 8.5, the `Dockerfile.build` was not building successfully. Now build correctly after removing `opcache` installation as it comes in php 8.5 binary.