### PR TITLE
Initialize custom exception handling

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -3,10 +3,12 @@
 namespace App\EventListener;
 
 use App\Exception\ApiException;
+use App\Exception\InternalServerException;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 #[AsEventListener(event: KernelEvents::EXCEPTION, method: 'onKernelException', priority: 10)]
@@ -21,17 +23,17 @@ class ExceptionListener
         $exception = $event->getThrowable();
 
         if ($exception instanceof ApiException) {
-            $errorDetails = $exception->getDetails();
-            $errorCode = $exception->getErrorCode();
-            $httpStatus = $exception->getCode();
-
-            $response = [
-                'errorCode' => $errorCode,
-                'details' => $errorDetails,
-            ];
-
-            $event->setResponse(new JsonResponse($response, $httpStatus));
+            $event->setResponse($this->getCustomExceptionJsonResponse($exception));
             return;
+        }
+        
+        // Handle Symfony HTTP exceptions
+        // In the future, `errorCode` could be more semantic based on specific HTTP error
+        if ($exception instanceof HttpExceptionInterface) {
+            $event->setResponse(new JsonResponse([
+                'errorCode' => 'HTTP_ERROR',
+                'details' => [],
+            ], $exception->getStatusCode()));
         }
 
         // Preserve default Symfony debug responses when error is unexpected
@@ -39,11 +41,21 @@ class ExceptionListener
             return;
         }
 
-        $response = [
-            'errorCode' => 'INTERNAL_SERVER_ERROR',
-        ];
+        $event->setResponse(
+            $this->getCustomExceptionJsonResponse(new InternalServerException($exception))
+        );
+    }
+
+    private function getCustomExceptionJsonResponse(ApiException $exception) {
+        $errorDetails = $exception->getDetails();
+        $errorCode = $exception->getErrorCode();
         $httpStatus = $exception->getCode();
 
-        $event->setResponse(new JsonResponse($response, $httpStatus));
+        $response = [
+            'errorCode' => $errorCode,
+            'details' => $errorDetails,
+        ];
+
+        return new JsonResponse($response, $httpStatus);
     }
 }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Exception\ApiException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+#[AsEventListener(event: KernelEvents::EXCEPTION, method: 'onKernelException', priority: 10)]
+class ExceptionListener
+{
+    public function __construct(
+        #[Autowire('%kernel.debug%')] private bool $isDebug
+    ) {}
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $exception = $event->getThrowable();
+
+        if ($exception instanceof ApiException) {
+            $errorDetails = $exception->getDetails();
+            $errorCode = $exception->getErrorCode();
+            $httpStatus = $exception->getCode();
+
+            $response = [
+                'errorCode' => $errorCode,
+                'details' => $errorDetails,
+            ];
+
+            $event->setResponse(new JsonResponse($response, $httpStatus));
+            return;
+        }
+
+        // Preserve default Symfony debug responses when error is unexpected
+        if ($this->isDebug) {
+            return;
+        }
+
+        $response = [
+            'errorCode' => 'INTERNAL_SERVER_ERROR',
+        ];
+        $httpStatus = $exception->getCode();
+
+        $event->setResponse(new JsonResponse($response, $httpStatus));
+    }
+}

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Exception;
+
+abstract class ApiException extends \RuntimeException
+{   
+    // Should uniquely describe an error type
+    protected string $errorCode;
+
+    // Contains any additional error info (e.g. form field errors)
+    protected array $details;
+
+    protected function __construct(
+        string $errorCode,
+        int $httpStatus,
+        string $message,
+        array $details = [],
+        ?\Throwable $cause = null, 
+    ) {
+        $this->errorCode = $errorCode;
+        $this->details = $details;
+
+        parent::__construct($message, $httpStatus, $cause);
+    }
+
+    public function getErrorCode(): string {
+        return $this->errorCode;
+    }
+
+    public function getDetails(): array {
+        return $this->details;
+    }
+}

--- a/src/Exception/InternalServerException.php
+++ b/src/Exception/InternalServerException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exception;
+
+class InternalServerException extends ApiException
+{
+    public function __construct(?\Throwable $cause = null)
+    {
+        parent::__construct('INTERNAL_SERVER_ERROR', 500, 'An internal server error has occurred.', [], $cause);
+    }
+}


### PR DESCRIPTION
Begins work on #1203

This starts work on a new approach to error handling in the backend. The goal is to eventually allow all errors to propagate to an exception event listener, which in turn will create a standardized error response. This takes the responsibility of creating error responses away from controllers. To handle errors, the source of an error (typically of a third-party service like MySQL or a network request) would be wrapped in a try/catch, and a custom error would be thrown in the catch block. After that, the error would propagate on its own and be caught by the error event listener, so no other handling is necessary.

In this PR, the abstract class that custom errors will extend from has been created as well as the listener to handle all errors. The `details` property of `ApiException` is intended to handle custom error info for more complex uses like form errors. The `errorCode` property should be set to a unique identifier for the error type. This identifier will be used on the frontend to determine an error message (if a message is displayed). Because of this, the `message` that is passed into the error is strictly used for debugging and will not be read by the end user.